### PR TITLE
コントローラーのID上書きバグ修正

### DIFF
--- a/src/interface/controller/CustomerController.ts
+++ b/src/interface/controller/CustomerController.ts
@@ -86,7 +86,8 @@ export class CustomerController {
   async updateCustomer(req: Request, res: Response): Promise<void> {
     try {
       const id = req.params.id;
-      const input = { id, ...req.body };
+      // URL の ID が常に優先されるようにする
+      const input = { ...req.body, id };
       const result = await this.updateCustomerUseCase.execute(input);
       res.status(200).json(result);
     } catch (error) {

--- a/src/interface/controller/__tests__/CustomerController.test.ts
+++ b/src/interface/controller/__tests__/CustomerController.test.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from "express";
+import { CustomerController } from "../CustomerController";
+
+// updateCustomer の ID の扱いをテストする
+
+describe("CustomerController.updateCustomer", () => {
+  it("URL の ID を優先して使用すること", async () => {
+    const executeMock = jest.fn().mockResolvedValue({});
+    const controller = new CustomerController(
+      {} as any,
+      {} as any,
+      {} as any,
+      { execute: executeMock } as any,
+      {} as any
+    );
+
+    const req = {
+      params: { id: "CUS-001" },
+      body: { id: "CUS-999" },
+    } as unknown as Request;
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as unknown as Response;
+
+    await controller.updateCustomer(req, res);
+
+    expect(executeMock).toHaveBeenCalledWith({ id: "CUS-001" });
+  });
+});


### PR DESCRIPTION
## 概要
`CustomerController` の `updateCustomer` メソッドで、URL パラメータの ID よりリクエストボディの ID が優先されてしまうバグを修正しました。これにより、意図しない顧客IDで更新処理が行われる問題を解消します。

## 変更点
- `updateCustomer` メソッドで入力生成時のプロパティ結合順序を修正
- 上記挙動を確認する単体テスト `CustomerController.test.ts` を追加

## テスト結果
- `npx jest --runInBand` を実行し、全 27 テストが成功することを確認しました。


------
https://chatgpt.com/codex/tasks/task_e_6841c45c13a4832eb4504b83054f67fc