### PR TITLE
READMEにCSV出力手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ src/
 - 購入履歴管理
 - 検索機能
 - データ入出力（CSV）
+- 顧客一覧の CSV 出力
 
 ## 開発方法
 
@@ -80,3 +81,24 @@ npm start
 ## データベース
 
 開発環境ではインメモリデータベースを使用しています。
+
+## CSV 出力
+
+`/customers/export` エンドポイントを利用すると、顧客一覧を CSV 形式で取得
+できます。クエリパラメータ `activeOnly` を指定すると、アクティブな顧客のみ
+を出力します。
+
+### リクエスト例
+
+```bash
+# すべての顧客を CSV で取得
+curl -L "http://localhost:3000/customers/export" -o customers.csv
+
+# アクティブな顧客のみを取得
+curl -L "http://localhost:3000/customers/export?activeOnly=true" -o customers.csv
+```
+
+### 返される内容
+
+レスポンスヘッダー `Content-Type: text/csv` が付与され、ボディに CSV データが
+含まれます。ファイル名は自由に指定できます。


### PR DESCRIPTION
## 概要
README に `/customers/export` を利用した CSV 出力方法を追記しました。

## 変更点
- 主な機能に「顧客一覧の CSV 出力」を追加
- `CSV 出力` セクションを新設し、リクエスト例と返される内容を説明
- サンプル `curl` コマンドを記載

## テスト結果
- `npm test` を実行し、全てのテストが成功することを確認しました。


------
https://chatgpt.com/codex/tasks/task_e_684998ade930832ea24449087bc37b02